### PR TITLE
refactor: reduce cyclomatic complexity of _get_inputs 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ htmlcov/
 
 # Windows
 Thumbs.db
+
+.vscode/
+env/


### PR DESCRIPTION
This PR refactors `_get_inputs` such that the cyclomatic complexity of the function is reduced 37.5% (from 16 to 10)

Original cyclomatic complexity:
```
  NLOC    CCN   token  PARAM  length  location
------------------------------------------------
      26     16    182      5      30 _get_inputs@115-144@./http/request/form.py
```
Improved cyclomatic complexity:
```
  NLOC    CCN   token  PARAM  length  location
------------------------------------------------
      24     10    156      5      28 _get_inputs@115-142@scrapy/http/request/form.py
```